### PR TITLE
Issue/msgpack

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,8 +18,8 @@ app.use(res_api);
 // jsonp callback setup
 app.set('jsonp callback name', 'callback');
 
-// use msgpack (if process.env.COMPRESS is 'msgpack')
-if (process.env.COMPRESS === 'msgpack') {
+// use msgpack to serialize json
+if (process.env.SERIALIZE === 'msgpack') {
   app.use(require('./app/middlewares/msgpack_json'));
 }
 

--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ var cookieParser  = require('cookie-parser');
 var bodyParser    = require('body-parser');
 var res_api       = require('res.api');
 var mount         = require('mount-routes');
-var log           = log4js.getLogger("moa-api");
+var log           = log4js.getLogger('moa-api');
 
 var app = express();
 
@@ -17,6 +17,11 @@ app.use(res_api);
 
 // jsonp callback setup
 app.set('jsonp callback name', 'callback');
+
+// use msgpack (if process.env.COMPRESS is 'msgpack')
+if (process.env.COMPRESS === 'msgpack') {
+  app.use(require('./app/middlewares/msgpack_json'));
+}
 
 // view engine setup
 app.set('views', path.join(__dirname, 'app/views'));
@@ -27,16 +32,15 @@ app.set('view engine', 'jade');
 
 // replace morgan with the log4js connect-logger
 log4js.configure('config/log4js.json', { reloadSecs: 300 });
-app.use(log4js.connectLogger(log4js.getLogger("http"), { level: 'auto' }));
+app.use(log4js.connectLogger(log4js.getLogger('http'), { level: 'auto' }));
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
- 
+
 // simple
 mount(app, __dirname + '/app/routes');
-
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/app/middlewares/msgpack_json.js
+++ b/app/middlewares/msgpack_json.js
@@ -1,0 +1,12 @@
+var msgpack = require('msgpack5')();
+
+module.exports = function  (req, res, next) {
+  res._json = res.json;
+
+  res.json = function (obj) {
+    if (!this.get('Content-Type')) this.set('Content-Type', 'application/x-msgpack');
+    res.send(msgpack.encode(obj));
+  };
+
+  next();
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cookie-parser": "~1.3.5",
     "debug": "~2.2.0",
     "express": "~4.13.1",
+    "jade": "^1.11.0",
     "jsonwebtoken": "^5.0.4",
     "log4js": "^0.6.26",
     "moa-plugin-user": "^1.0.1",
@@ -22,6 +23,7 @@
     "mount-middlewares": "^1.0.5",
     "mount-routes": "^1.0.3",
     "mount-services": "^1.0.7",
+    "msgpack5": "^3.1.0",
     "res.api": "^1.0.11",
     "serve-favicon": "~2.3.0"
   },

--- a/test/controller/test.js
+++ b/test/controller/test.js
@@ -6,11 +6,11 @@ require('chai').should();
 var app = require('../../app');
 
 describe('GET /users', function(){
-  it('respond with json', function(done){
+  it('respond with json or msgpack', function(done){
     request(app)
       .get('/api/user/login')
       .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
+      .expect('Content-Type', /json|msgpack/)
       .expect(200, done);
   })
 })

--- a/test/controller/users_controller.js
+++ b/test/controller/users_controller.js
@@ -6,11 +6,11 @@ require('chai').should();
 var app = require('../../app');
 
 describe('GET /users', function(){
-  it('respond with json', function(done){
+  it('respond with json or msgpack', function(done){
     request(app)
       .get('/api/user/login')
       .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
+      .expect('Content-Type', /json|msgpack/)
       .expect(200, done);
   })
 })


### PR DESCRIPTION
1，支持使用msgpack序列化json，客户端也需要对应的进行`decode`。目前默认是不开启的。若要开启，需将`process.env.SERIALIZE`设为`'msgpack'`：如`SERIALIZE=msgpack node bin/www`。（ issue #4 ）
2，添加了遗漏的依赖项`jade`。
